### PR TITLE
Adding init script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,2 +1,2 @@
 # replace the Devise secret key with a random string
-sed -i "" "s/<YOUR-SECRET-KEY>/`LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 128`/g" Autolab/docker/devise.rb
+sed -i"" "s/<YOUR-SECRET-KEY>/`LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 128`/g" Autolab/docker/devise.rb

--- a/setup.sh
+++ b/setup.sh
@@ -1,2 +1,2 @@
-
+# replace the Devise secret key with a random string
 sed -i "" "s/<YOUR-SECRET-KEY>/`LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 128`/g" Autolab/docker/devise.rb

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,2 @@
+
+sed -i "" "s/<YOUR-SECRET-KEY>/`LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 128`/g" Autolab/docker/devise.rb


### PR DESCRIPTION
Added a setup.sh which should be run before `docker-compose up` for the first time (consider running `docker-compose build --no-cache` to clear existing build cache). 

**How it is tested:**
After running `sh setup.sh && docker-compose up`, I sshed into the docker container (`docker exec -it docker_autolab_1 /bin/bash`) and examined config/initializers/devise.rb. `config.secret_key` had been changed to a random string as expected. 