### PR TITLE
config.template.py redis hostname fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,9 @@ update:
 
 .PHONY: clean
 clean:
-	rm -r ./Autolab/config/database.yml
-	rm -r ./Autolab/config/school.yml
-	rm -r ./Autolab/config/initializers/devise.rb
-	rm -r ./Autolab/config/environments/production.rb
-	rm -r ./Autolab/config/autogradeConfig.rb
+	rm -rf ./Autolab/config/database.yml
+	rm -rf ./Autolab/config/school.yml
+	rm -rf ./Autolab/config/initializers/devise.rb
+	rm -rf ./Autolab/config/environments/production.rb
+	rm -rf ./Autolab/config/autogradeConfig.rb
+	rm -rf ./Tango/config.py

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-setup-configs: 
+all: setup-autolab-configs setup-tango-configs
+
+.PHONY: setup-autolab-configs
+setup-autolab-configs: 
 	echo "Creating default Autolab/config/database.yml"
 	cp -n ./Autolab/config/database.docker.yml ./Autolab/config/database.yml
 
@@ -18,6 +21,11 @@ setup-configs:
 	echo "Creating default Autolab/config/autogradeConfig.rb"
 	cp -n ./Autolab/config/autogradeConfig.rb.template ./Autolab/config/autogradeConfig.rb
 
+.PHONY: setup-tango-configs
+setup-tango-configs: 
+	echo "Creating default Tango/config.py"
+	cp -n ./Tango/config.template.py ./Tango/config.py
+
 db-migrate:
 	docker exec -it autolab bash /home/app/webapp/docker/db_migrate.sh
 
@@ -27,7 +35,7 @@ update:
 	cd ./Tango && git checkout master && git pull origin master
 	cd ..
 
-	
+.PHONY: clean
 clean:
 	rm -r ./Autolab/config/database.yml
 	rm -r ./Autolab/config/school.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,11 +14,12 @@ services:
       - "redis"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ./Tango/config.template.py:/opt/TangoService/Tango/config.py
+      - ./Tango/config.py:/opt/TangoService/Tango/config.py
     environment:
       - DOCKER_DEPLOYMENT=prod
       # do not modify
       - DOCKER_VOLUME_PATH=/opt/TangoService/Tango/volumes/
+      - DOCKER_REDIS_HOSTNAME=redis
   autolab:
     container_name: autolab
     ports:


### PR DESCRIPTION
This sovles #10 where Tango was crash looping because the Redis hostname was not being set (thanks @carlosnatalino!). This PR addresses the issue, along with other minor changes:

1. Require config.py to be explicitly copied instead of implicitly using config.template.py, which should be the case for user customizable configs
2. Add the -f flag to the `rm` commands in make clean to silently ignore if files don't already exist

To test: 
1. In ./Tango, checkout to `docker-config-update` branch
2. `make clean`
3. `make`
4. `docker-compose build`
5. `docker-compose up`