### PR TITLE
Permissions fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,39 +2,48 @@ all: setup-autolab-configs setup-tango-configs
 
 .PHONY: setup-autolab-configs
 setup-autolab-configs: 
-	echo "Creating default Autolab/config/database.yml"
+	@echo "Creating default Autolab/config/database.yml"
 	cp -n ./Autolab/config/database.docker.yml ./Autolab/config/database.yml
 
-	echo "Creating default Autolab/config/school.yml"
+	@echo "Creating default Autolab/config/school.yml"
 	cp -n ./Autolab/config/school.yml.template ./Autolab/config/school.yml
 
-	echo "Creating default Autolab/config/initializers/devise.rb"
+	@echo "Creating default Autolab/config/initializers/devise.rb"
 	cp -n ./Autolab/config/initializers/devise.rb.template ./Autolab/config/initializers/devise.rb
 
 	# Replace the Devise secret key with a random string
-	echo "Setting random Devise secret"
+	@echo "Setting random Devise secret"
 	sed -i.bak "s/<YOUR-SECRET-KEY>/`LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 128`/g" ./Autolab/config/initializers/devise.rb && rm ./Autolab/config/initializers/devise.rb.bak
 
-	echo "Creating default Autolab/config/environments/production.rb"
+	@echo "Creating default Autolab/config/environments/production.rb"
 	cp -n ./Autolab/config/environments/production.rb.template ./Autolab/config/environments/production.rb
 
-	echo "Creating default Autolab/config/autogradeConfig.rb"
+	@echo "Creating default Autolab/config/autogradeConfig.rb"
 	cp -n ./Autolab/config/autogradeConfig.rb.template ./Autolab/config/autogradeConfig.rb
+
+	@echo "Creating default Autolab/courses"
+	mkdir -p ./Autolab/courses
 
 .PHONY: setup-tango-configs
 setup-tango-configs: 
 	echo "Creating default Tango/config.py"
 	cp -n ./Tango/config.template.py ./Tango/config.py
 
+.PHONY: db-migrate
 db-migrate:
 	docker exec -it autolab bash /home/app/webapp/docker/db_migrate.sh
 
+.PHONY: update
 update:
 	cd ./Autolab && git checkout master && git pull origin master
 	cd ..
 	cd ./Tango && git checkout master && git pull origin master
 	cd ..
 
+.PHONY: set-perms
+set-perms:
+	docker exec -it autolab chown -R app:app /home/app/webapp
+	
 .PHONY: clean
 clean:
 	rm -rf ./Autolab/config/database.yml
@@ -43,3 +52,4 @@ clean:
 	rm -rf ./Autolab/config/environments/production.rb
 	rm -rf ./Autolab/config/autogradeConfig.rb
 	rm -rf ./Tango/config.py
+	# We don't remove Autolab/courses here, as it may contain important user data. Remove it yourself manually if needed.

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,10 @@ update:
 .PHONY: set-perms
 set-perms:
 	docker exec -it autolab chown -R app:app /home/app/webapp
+
+.PHONY: create-user
+create-user:
+	docker exec -it autolab bash /home/app/webapp/docker/initialize_user.sh
 	
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ First ensure that you have Docker installed on your machine.
 6. Run the containers: `docker-compose up`
 7. Ensure that the newly created config files have the right permissions: `make set-perms`
 8. Perform migrations: `make db-migrate`
-9. Create initial root user: `make create-root`
+9. Create initial root user: `make create-user`

--- a/README.md
+++ b/README.md
@@ -9,5 +9,6 @@ First ensure that you have Docker installed on your machine.
 4. Create initial configs: `make`
 5. Build the Dockerfiles: `docker-compose build`
 6. Run the containers: `docker-compose up`
-7. Perform migrations: `make db-migrate`
-8. Create initial root user: `make create-root`
+7. Ensure that the newly created config files have the right permissions: `make set-perms`
+8. Perform migrations: `make db-migrate`
+9. Create initial root user: `make create-root`


### PR DESCRIPTION
This resolves #12 by adding an additional step to ensure that all newly created config files get the right permissions after they have been created by the user.

This also slightly improves the Makefile printing by suppressing printing of the echo commands, since they are meant to print things anyway

To test:
Follow same steps as in the new README