### PR TITLE
Define Tango key environment variables for Tango container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - ./Tango/config.py:/opt/TangoService/Tango/config.py
     environment:
       - DOCKER_DEPLOYMENT=prod
+      - RESTFUL_KEY=REPLACE_ME_SECRET_TANGO_KEY
       # do not modify
       - DOCKER_VOLUME_PATH=/opt/TangoService/Tango/volumes/
       - DOCKER_REDIS_HOSTNAME=redis


### PR DESCRIPTION
The key to use for the docker-compose installation currently isn't being propagated to the config file, which this aims to fix. This results in Tango complaining that Autolab is using the wrong key, and therefore rejects all requests.

This is meant to be reviewed together with https://github.com/autolab/Tango/compare/tango-docker-key-fix