### PR TITLE
Support using own SSL certs for deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .idea/
 ssl/certbot/
+ssl/fullchain.pem
+ssl/privkey.pem
+ssl/ssl-dhparams.pem
 init-letsencrypt.sh
+

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ First ensure that you have Docker installed on your machine.
 9. Create initial root user: `make create-user`
 10. Perform SSL setup. 
  
-	*Option 1 with Let's Encrypt:*
+	**Option 1 with Let's Encrypt:**
  
     1. Ensure that your DNS record points towards the IP address of your server
     2. Ensure that port 443 is exposed on your server (i.e checking your firewall, AWS security group settings, etc)
@@ -25,7 +25,7 @@ First ensure that you have Docker installed on your machine.
     7. Run your modified script: `sudo sh ./ssl/init-letsencrypt.sh`
 	     
 	     
-	*Option 2 with your own SSL certificate:*
+	**Option 2 with your own SSL certificate:**
  
     1. Copy your private key to ./ssl/privkey.pem
     2. Copy your certificate to ./ssl/fullchain.pem

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ First ensure that you have Docker installed on your machine.
 10. Perform SSL setup. 
  
 	Option 1 with Let's Encrypt:
+ 
 	    1. Ensure that your DNS record points towards the IP address of your server
 	    2. Ensure that port 443 is exposed on your server (i.e checking your firewall, AWS security group settings, etc)
 	    3.  Get initial SSL setup script: `make ssl`
@@ -25,6 +26,7 @@ First ensure that you have Docker installed on your machine.
 	     
 	     
 	Option 2 with your own SSL certificate:
+ 
 	    1. Copy your private key to ./ssl/privkey.pem
 	    2. Copy your certificate to ./ssl/fullchain.pem
 	    3. Uncomment the following lines in `docker-compose.yml`:

--- a/README.md
+++ b/README.md
@@ -13,18 +13,21 @@ First ensure that you have Docker installed on your machine.
 8. Perform migrations: `make db-migrate`
 9. Create initial root user: `make create-user`
 10. Perform SSL setup. 
-11a. Option 1 with Let's Encrypt:
-    1. Ensure that your DNS record points towards the IP address of your server
-    2. Ensure that port 443 is exposed on your server (i.e checking your firewall, AWS security group settings, etc)
-    3.  Get initial SSL setup script: `make ssl`
-    4. In `ssl/init-letsencrypt.sh`, change `domains=(example.com)` to the list of domains that your host is associated with, and change `email` to be your email address so that Let's Encrypt will be able to email you when your certificate is about to expire
-    5. If necessary, change `staging=0` to `staging=1` to avoid being rate-limited by Let's Encrypt since there is a limit of 20 certificates/week. Setting this is helpful if you have an experimental setup.
-    6. Stop your containers: `docker-compose stop`
-    7. Run your modified script: `sudo sh ./ssl/init-letsencrypt.sh`
-11b. Option 2 with your own SSL certificate:
-    1. Copy your private key to ./ssl/privkey.pem
-    2. Copy your certificate to ./ssl/fullchain.pem
-    3. Uncomment the following lines in `docker-compose.yml`:
+ 
+	Option 1 with Let's Encrypt:
+	    1. Ensure that your DNS record points towards the IP address of your server
+	    2. Ensure that port 443 is exposed on your server (i.e checking your firewall, AWS security group settings, etc)
+	    3.  Get initial SSL setup script: `make ssl`
+	    4. In `ssl/init-letsencrypt.sh`, change `domains=(example.com)` to the list of domains that your host is associated with, and change `email` to be your email address so that Let's Encrypt will be able to email you when your certificate is about to expire
+	    5. If necessary, change `staging=0` to `staging=1` to avoid being rate-limited by Let's Encrypt since there is a limit of 20 certificates/week. Setting this is helpful if you have an experimental setup.
+	    6. Stop your containers: `docker-compose stop`
+	    7. Run your modified script: `sudo sh ./ssl/init-letsencrypt.sh`
+	     
+	     
+	Option 2 with your own SSL certificate:
+	    1. Copy your private key to ./ssl/privkey.pem
+	    2. Copy your certificate to ./ssl/fullchain.pem
+	    3. Uncomment the following lines in `docker-compose.yml`:
      
     ```
        # - ./ssl/fullchain.pem:/etc/letsencrypt/live/test.autolab.io/fullchain.pem;

--- a/README.md
+++ b/README.md
@@ -27,13 +27,16 @@ First ensure that you have Docker installed on your machine.
 	     
 	**Option 2 with your own SSL certificate:**
  
-    1. Copy your private key to ./ssl/privkey.pem
-    2. Copy your certificate to ./ssl/fullchain.pem
-    3. Uncomment the following lines in `docker-compose.yml`:
+    1. Stop all containers: `docker-compose stop`
+    2. Copy your private key to ./ssl/privkey.pem
+    3. Copy your certificate to ./ssl/fullchain.pem
+    4. Generate your dhparams, i.e `openssl dhparam -out ./ssl/ssl-dhparams.pem 4096`
+    5. Uncomment the following lines in `docker-compose.yml`:
      
     ```
        # - ./ssl/fullchain.pem:/etc/letsencrypt/live/test.autolab.io/fullchain.pem;
        # - ./ssl/privkey.pem:/etc/letsencrypt/live/test.autolab.io/privkey.pem;
+       # - ./ssl/ssl-dhparams.pem:/etc/letsencrypt/ssl-dhparams.pem
     ```
 12. Start up everything: `docker-compose up -d`
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ First ensure that you have Docker installed on your machine.
 7. Ensure that the newly created config files have the right permissions: `make set-perms`
 8. Perform migrations: `make db-migrate`
 9. Create initial root user: `make create-user`
-10. Perform SSL setup:
+10. Perform SSL setup. 
+11a. Option 1 with Let's Encrypt:
     1. Ensure that your DNS record points towards the IP address of your server
     2. Ensure that port 443 is exposed on your server (i.e checking your firewall, AWS security group settings, etc)
     3.  Get initial SSL setup script: `make ssl`
@@ -20,7 +21,13 @@ First ensure that you have Docker installed on your machine.
     5. If necessary, change `staging=0` to `staging=1` to avoid being rate-limited by Let's Encrypt since there is a limit of 20 certificates/week. Setting this is helpful if you have an experimental setup.
     6. Stop your containers: `docker-compose stop`
     7. Run your modified script: `sudo sh ./ssl/init-letsencrypt.sh`
-11. Start up everything: `docker-compose up -d`
+11b. Option 2 with your own SSL certificate:
+    1. Copy your private key to ./ssl/privkey.pem
+    2. Copy your certificate to ./ssl/fullchain.pem
+    3. Uncomment the following lines in `docker-compose.yml`:
+      > # - ./ssl/fullchain.pem:/etc/letsencrypt/live/test.autolab.io/fullchain.pem;
+      > # - ./ssl/privkey.pem:/etc/letsencrypt/live/test.autolab.io/privkey.pem;
+12. Start up everything: `docker-compose up -d`
 
 ## Future Start-up Instructions
 After you have done your initial set-up, you can start your containers up again by simply running `docker-compose up -d`. 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ First ensure that you have Docker installed on your machine.
     1. Copy your private key to ./ssl/privkey.pem
     2. Copy your certificate to ./ssl/fullchain.pem
     3. Uncomment the following lines in `docker-compose.yml`:
-      > # - ./ssl/fullchain.pem:/etc/letsencrypt/live/test.autolab.io/fullchain.pem;
-      > # - ./ssl/privkey.pem:/etc/letsencrypt/live/test.autolab.io/privkey.pem;
+     
+    ```
+       # - ./ssl/fullchain.pem:/etc/letsencrypt/live/test.autolab.io/fullchain.pem;
+       # - ./ssl/privkey.pem:/etc/letsencrypt/live/test.autolab.io/privkey.pem;
+    ```
 12. Start up everything: `docker-compose up -d`
 
 ## Future Start-up Instructions

--- a/README.md
+++ b/README.md
@@ -14,22 +14,22 @@ First ensure that you have Docker installed on your machine.
 9. Create initial root user: `make create-user`
 10. Perform SSL setup. 
  
-	Option 1 with Let's Encrypt:
+	*Option 1 with Let's Encrypt:*
  
-	    1. Ensure that your DNS record points towards the IP address of your server
-	    2. Ensure that port 443 is exposed on your server (i.e checking your firewall, AWS security group settings, etc)
-	    3.  Get initial SSL setup script: `make ssl`
-	    4. In `ssl/init-letsencrypt.sh`, change `domains=(example.com)` to the list of domains that your host is associated with, and change `email` to be your email address so that Let's Encrypt will be able to email you when your certificate is about to expire
-	    5. If necessary, change `staging=0` to `staging=1` to avoid being rate-limited by Let's Encrypt since there is a limit of 20 certificates/week. Setting this is helpful if you have an experimental setup.
-	    6. Stop your containers: `docker-compose stop`
-	    7. Run your modified script: `sudo sh ./ssl/init-letsencrypt.sh`
+    1. Ensure that your DNS record points towards the IP address of your server
+    2. Ensure that port 443 is exposed on your server (i.e checking your firewall, AWS security group settings, etc)
+    3.  Get initial SSL setup script: `make ssl`
+    4. In `ssl/init-letsencrypt.sh`, change `domains=(example.com)` to the list of domains that your host is associated with, and change `email` to be your email address so that Let's Encrypt will be able to email you when your certificate is about to expire
+    5. If necessary, change `staging=0` to `staging=1` to avoid being rate-limited by Let's Encrypt since there is a limit of 20 certificates/week. Setting this is helpful if you have an experimental setup.
+    6. Stop your containers: `docker-compose stop`
+    7. Run your modified script: `sudo sh ./ssl/init-letsencrypt.sh`
 	     
 	     
-	Option 2 with your own SSL certificate:
+	*Option 2 with your own SSL certificate:*
  
-	    1. Copy your private key to ./ssl/privkey.pem
-	    2. Copy your certificate to ./ssl/fullchain.pem
-	    3. Uncomment the following lines in `docker-compose.yml`:
+    1. Copy your private key to ./ssl/privkey.pem
+    2. Copy your certificate to ./ssl/fullchain.pem
+    3. Uncomment the following lines in `docker-compose.yml`:
      
     ```
        # - ./ssl/fullchain.pem:/etc/letsencrypt/live/test.autolab.io/fullchain.pem;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,8 +45,9 @@ services:
       - ./ssl/certbot/www:/var/www/certbot
 
       # Uncomment the below if you are using your own certificate
-      # - ./ssl/fullchain.pem:/etc/letsencrypt/live/test.autolab.io/fullchain.pem;
-      # - ./ssl/privkey.pem:/etc/letsencrypt/live/test.autolab.io/privkey.pem;
+      # - ./ssl/fullchain.pem:/etc/letsencrypt/live/test.autolab.io/fullchain.pem
+      # - ./ssl/privkey.pem:/etc/letsencrypt/live/test.autolab.io/privkey.pem
+      # - ./ssl/ssl-dhparams.pem:/etc/letsencrypt/ssl-dhparams.pem
 
       # Comment the below out to disable SSL (not recommended)
       - ./nginx/app.conf:/etc/nginx/sites-enabled/webapp.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,10 @@ services:
       - ./ssl/certbot/conf:/etc/letsencrypt
       - ./ssl/certbot/www:/var/www/certbot
 
+      # Uncomment the below if you are using your own certificate
+      # - ./ssl/fullchain.pem:/etc/letsencrypt/live/test.autolab.io/fullchain.pem;
+      # - ./ssl/privkey.pem:/etc/letsencrypt/live/test.autolab.io/privkey.pem;
+
       # Comment the below out to disable SSL (not recommended)
       - ./nginx/app.conf:/etc/nginx/sites-enabled/webapp.conf
 

--- a/nginx/app.conf
+++ b/nginx/app.conf
@@ -29,7 +29,15 @@ server {
     ssl_certificate /etc/letsencrypt/live/test.autolab.io/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/test.autolab.io/privkey.pem;
 
-    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_session_cache shared:le_nginx_SSL:10m;
+    ssl_session_timeout 1440m;
+    ssl_session_tickets off;
+    
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
+
+    ssl_ciphers "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384";
+
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
 }


### PR DESCRIPTION
This allows users to use their own certificates for SSL.

Follow instructions in the updated README.md on how to replicate. 

I used https://www.selfsignedcertificate.com/ to self-sign a certificate.

Result (run locally):

![Screenshot_20201103_143936](https://user-images.githubusercontent.com/9707110/98032713-6a68ce80-1de2-11eb-9a9b-41d8512e9e2d.png)

Of course it's actually an invalid certificate since it was self-signed, but it's a POC