### PR TITLE
mysql credentials config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,12 @@ setup-autolab-configs:
 	# Replace the Devise secret key with a random string
 	@echo "Setting random Devise secret"
 	sed -i.bak "s/<YOUR-SECRET-KEY>/`LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 128`/g" ./Autolab/config/initializers/devise.rb && rm ./Autolab/config/initializers/devise.rb.bak
+    # Replace database credentials with the ones set by user in docker-compose
+	@echo "Setting database username"
+	sed -i.bak "s/<MYSQL_USERNAME>/`sed -n -e '/MYSQL_USER/ s/.*\= *//p' docker-compose.yml`/g" ./Autolab/config/database.yml && rm ./Autolab/config/database.yml.bak
+
+	@echo "Setting database password"
+	sed -i.bak "s/<MYSQL_PASSWORD>/`sed -n -e '/MYSQL_PASSWORD/ s/.*\= *//p' docker-compose.yml`/g" ./Autolab/config/database.yml && rm ./Autolab/config/database.yml.bak
 
 	@echo "Creating default Autolab/config/environments/production.rb"
 	cp -n ./Autolab/config/environments/production.rb.template ./Autolab/config/environments/production.rb


### PR DESCRIPTION
Change `username` and `password` in ./Autolab/config/database.yml according to the credentials user provided in docker-compose.yml (as part of the `make` command), so there is only one file that the user needs to change without having to navigate to the Autolab submodule. 

How to test: 
1. checkout `docker-mysql-credentials` branch in Autolab 
2. change `MYSQL_USER` and `MYSQL_PASSWORD` in docker-compose.yml to customized credentials 
3. `make clean && make`, check that  ./Autolab/config/database.yml has the right credentials