### PR TITLE
Autograding fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,10 +20,11 @@ services:
     environment:
       - DOCKER_DEPLOYMENT=prod
       - RESTFUL_KEY=REPLACE_ME_SECRET_TANGO_KEY
-      - DOCKER_VOLUME_PATH=/opt/TangoService/Tango/volumes
-      - DOCKER_TANGO_HOST_VOLUME_PATH=/home/ec2-user/autolab-docker/Tango/volumes
-      # do not modify
       - DOCKER_REDIS_HOSTNAME=redis
+      # Path to volumes within the Tango container. Does not need to be modified.
+      - DOCKER_VOLUME_PATH=/opt/TangoService/Tango/volumes
+      # Modify the below to be the path to volumes on your host machine
+      - DOCKER_TANGO_HOST_VOLUME_PATH=/home/ec2-user/autolab-docker/Tango/volumes
 
   autolab:
     container_name: autolab

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,11 +16,12 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./Tango/config.py:/opt/TangoService/Tango/config.py
+      - ./Tango/volumes:/opt/TangoService/Tango/volumes
     environment:
       - DOCKER_DEPLOYMENT=prod
       - RESTFUL_KEY=REPLACE_ME_SECRET_TANGO_KEY
+      - DOCKER_VOLUME_PATH=/home/ec2-user/autolab-docker/Tango/volumes
       # do not modify
-      - DOCKER_VOLUME_PATH=/opt/TangoService/Tango/volumes/
       - DOCKER_REDIS_HOSTNAME=redis
 
   autolab:
@@ -50,13 +51,13 @@ services:
       # - ./ssl/ssl-dhparams.pem:/etc/letsencrypt/ssl-dhparams.pem
 
       # Comment the below out to disable SSL (not recommended)
-      - ./nginx/app.conf:/etc/nginx/sites-enabled/webapp.conf
+      # - ./nginx/app.conf:/etc/nginx/sites-enabled/webapp.conf
 
       # Uncomment the below to disable SSL (not recommended)
-      # - ./nginx/no-ssl-app.conf:/etc/nginx/sites-enabled/webapp.conf
+      - ./nginx/no-ssl-app.conf:/etc/nginx/sites-enabled/webapp.conf
 
     environment:
-      - DOCKER_SSL=true                         # set to false for no SSL (not recommended)
+      - DOCKER_SSL=false # set to false for no SSL (not recommended)
       - RESTFUL_HOST=tango
       - RESTFUL_PORT=3000
       - RESTFUL_KEY=REPLACE_ME_SECRET_TANGO_KEY
@@ -66,11 +67,11 @@ services:
     image: mysql/mysql-server:latest
     environment:
       - MYSQL_DATABASE=autolab_development
-      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_ROOT_PASSWORD=fanpu
       - MYSQL_HOST=localhost
       - MYSQL_PORT=3306
-      - MYSQL_USER=user
-      - MYSQL_PASSWORD=password
+      - MYSQL_USER=fanpu
+      - MYSQL_PASSWORD=password123
     volumes:
       - mysql-db:/var/lib/mysql
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,3 +85,4 @@ services:
 
 volumes:
   mysql-db:
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,11 +68,11 @@ services:
     image: mysql/mysql-server:latest
     environment:
       - MYSQL_DATABASE=autolab_development
-      - MYSQL_ROOT_PASSWORD=fanpu
+      - MYSQL_ROOT_PASSWORD=root
       - MYSQL_HOST=localhost
       - MYSQL_PORT=3306
-      - MYSQL_USER=fanpu
-      - MYSQL_PASSWORD=password123
+      - MYSQL_USER=user
+      - MYSQL_PASSWORD=password
     volumes:
       - mysql-db:/var/lib/mysql
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,8 @@ services:
     environment:
       - DOCKER_DEPLOYMENT=prod
       - RESTFUL_KEY=REPLACE_ME_SECRET_TANGO_KEY
-      - DOCKER_VOLUME_PATH=/home/ec2-user/autolab-docker/Tango/volumes
+      - DOCKER_VOLUME_PATH=/opt/TangoService/Tango/volumes
+      - DOCKER_TANGO_HOST_VOLUME_PATH=/home/ec2-user/autolab-docker/Tango/volumes
       # do not modify
       - DOCKER_REDIS_HOSTNAME=redis
 
@@ -51,13 +52,13 @@ services:
       # - ./ssl/ssl-dhparams.pem:/etc/letsencrypt/ssl-dhparams.pem
 
       # Comment the below out to disable SSL (not recommended)
-      # - ./nginx/app.conf:/etc/nginx/sites-enabled/webapp.conf
+      - ./nginx/app.conf:/etc/nginx/sites-enabled/webapp.conf
 
       # Uncomment the below to disable SSL (not recommended)
-      - ./nginx/no-ssl-app.conf:/etc/nginx/sites-enabled/webapp.conf
+      # - ./nginx/no-ssl-app.conf:/etc/nginx/sites-enabled/webapp.conf
 
     environment:
-      - DOCKER_SSL=false # set to false for no SSL (not recommended)
+      - DOCKER_SSL=true # set to false for no SSL (not recommended)
       - RESTFUL_HOST=tango
       - RESTFUL_PORT=3000
       - RESTFUL_KEY=REPLACE_ME_SECRET_TANGO_KEY


### PR DESCRIPTION
This fixes issues with autograding. This is because:
1. When Tango runs a job, it uses the same Docker server as the host since we perform volume mapping. However, when Tango runs a job it also tries to perform a volume mapping in order to retrieve the feedback. This volume mapping in reality is relative to the host instead of within the container, causing it to fail.
2. assessmentConfig was not volume mapped. This causes failures in retrieving a course subsequently

Testing instructions: same as usual setup, but now also create a course, then create an autograded assignment, and run a sample job on it