### PR TITLE
Add note on directory to run init-letsencrypt.sh

### DIFF
--- a/ssl/init-letsencrypt.sh.template
+++ b/ssl/init-letsencrypt.sh.template
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Adapted from https://github.com/wmnnd/nginx-certbot
+# Run this from the root of the Autolab docker installation directory (not from the ssl subdirectory)
 
 if ! [ -x "$(command -v docker-compose)" ]; then
   echo 'Error: docker-compose is not installed.' >&2


### PR DESCRIPTION
This is to avoid confusion over which directory to run the script from, because if you run init-letsencrypt.sh from the ssl folder the data_path will be wrong.