### PR TITLE
Changed assessmentConfig volume path to keep assessmentConfig upon redeployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - ./Autolab/config/autogradeConfig.rb:/home/app/webapp/config/autogradeConfig.rb
       - ./Autolab/courses:/home/app/webapp/courses
       - ./Autolab/courseConfig:/home/app/webapp/courseConfig
-      - ./Autolab/assessmentConfig:/home/app/webapp/courses/assessmentConfig
+      - ./Autolab/assessmentConfig:/home/app/webapp/assessmentConfig
       - ./ssl/certbot/conf:/etc/letsencrypt
       - ./ssl/certbot/www:/var/www/certbot
 


### PR DESCRIPTION
assessmentConfig volume mapping in docker-compose is changed to reflect the path where autolab checks for assessmentConfig.rb file

Steps to reproduce: 
 - do `docker-compose build` of an existing course which contains an assessment
 - Navigate to the assessment page 
 - it should through an error showing 500 - internal error
 - clicking "Reload Assessment Config" fixes the issue


Attached the error screenshot: 
![image](https://user-images.githubusercontent.com/15074408/136182553-bd7f46b1-cd96-4bd3-b0f5-1759f4eb1d10.png)