### PR TITLE
Default server name becomes localhost for no SSL option

### DIFF
--- a/nginx/no-ssl-app.conf
+++ b/nginx/no-ssl-app.conf
@@ -1,6 +1,6 @@
 server {
   listen 80;
-  server_name example.com;
+  server_name localhost;
   root /home/app/webapp/public;
   passenger_enabled on;
   passenger_user app;


### PR DESCRIPTION
No SSL is mostly used for development purposes. It is more convenient for developers if the default server name is localhost.