### PR TITLE
Update installation with devise config removal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,6 @@ setup-autolab-configs:
 	@echo "Creating default Autolab/config/school.yml"
 	cp -n ./Autolab/config/school.yml.template ./Autolab/config/school.yml
 
-	@echo "Creating default Autolab/config/initializers/devise.rb"
-	cp -n ./Autolab/config/initializers/devise.rb.template ./Autolab/config/initializers/devise.rb
-
-	# Replace the Devise secret key with a random string
-	@echo "Setting random Devise secret"
-	sed -i.bak "s/<YOUR-SECRET-KEY>/`LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 128`/g" ./Autolab/config/initializers/devise.rb && rm ./Autolab/config/initializers/devise.rb.bak
-
 	@echo "Creating default Autolab/config/environments/production.rb"
 	cp -n ./Autolab/config/environments/production.rb.template ./Autolab/config/environments/production.rb
 
@@ -60,7 +53,6 @@ ssl:
 clean:
 	rm -rf ./Autolab/config/database.yml
 	rm -rf ./Autolab/config/school.yml
-	rm -rf ./Autolab/config/initializers/devise.rb
 	rm -rf ./Autolab/config/environments/production.rb
 	rm -rf ./Autolab/config/autogradeConfig.rb
 	rm -rf ./Tango/config.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,6 @@ services:
     volumes:
       - ./Autolab/db/:/home/app/webapp/db
       - ./Autolab/config/database.yml:/home/app/webapp/config/database.yml
-      - ./Autolab/config/initializers/devise.rb:/home/app/webapp/config/initializers/devise.rb
       - ./Autolab/config/environments/production.rb:/home/app/webapp/config/environments/production.rb
       - ./Autolab/config/autogradeConfig.rb:/home/app/webapp/config/autogradeConfig.rb
       - ./Autolab/courses:/home/app/webapp/courses


### PR DESCRIPTION
We have moved devise secrets to .env (https://github.com/autolab/Autolab/pull/1430), so the steps related to copying devise are no longer needed