### PR TITLE
Move variable options from docker-compose.yml into .env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,12 +2,21 @@
 DOCKER_DEPLOYMENT=prod
 RESTFUL_KEY=REPLACE_ME_SECRET_TANGO_KEY
 DOCKER_REDIS_HOSTNAME=redis
+
 # Path to volumes within the Tango container. Does not need to be modified.
 DOCKER_VOLUME_PATH=/opt/TangoService/Tango/volumes
+
 # Modify the below to be the path to volumes on your host machine
 DOCKER_TANGO_HOST_VOLUME_PATH=/home/ec2-user/autolab-docker/Tango/volumes
-# set to false for no SSL (not recommended)
+
+# Set to false for no SSL (not recommended)
 DOCKER_SSL=true
+
+# Nginx config location
+# Set to either:
+# With SSL: ./nginx/app.conf
+# Without SSL: ./nginx/no-ssl-app.conf
+NGINX_CONFIG=./nginx/app.conf
 
 # TANGO
 RESTFUL_HOST=tango

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,9 +21,7 @@ services:
       - DOCKER_DEPLOYMENT
       - RESTFUL_KEY
       - DOCKER_REDIS_HOSTNAME
-      # Path to volumes within the Tango container. Does not need to be modified.
       - DOCKER_VOLUME_PATH
-      # Modify the below to be the path to volumes on your host machine
       - DOCKER_TANGO_HOST_VOLUME_PATH
 
   autolab:
@@ -40,7 +38,6 @@ services:
     volumes:
       - ./Autolab/db/:/home/app/webapp/db
       - ./Autolab/config/database.yml:/home/app/webapp/config/database.yml
-      - ./Autolab/config/initializers/devise.rb:/home/app/webapp/config/initializers/devise.rb
       - ./Autolab/config/environments/production.rb:/home/app/webapp/config/environments/production.rb
       - ./Autolab/config/autogradeConfig.rb:/home/app/webapp/config/autogradeConfig.rb
       - ./Autolab/courses:/home/app/webapp/courses
@@ -54,11 +51,7 @@ services:
       # - ./ssl/privkey.pem:/etc/letsencrypt/live/test.autolab.io/privkey.pem
       # - ./ssl/ssl-dhparams.pem:/etc/letsencrypt/ssl-dhparams.pem
 
-      # Comment the below out to disable SSL (not recommended)
-      - ./nginx/app.conf:/etc/nginx/sites-enabled/webapp.conf
-
-      # Uncomment the below to disable SSL (not recommended)
-      # - ./nginx/no-ssl-app.conf:/etc/nginx/sites-enabled/webapp.conf
+      - ${NGINX_CONFIG}:/etc/nginx/sites-enabled/webapp.conf
 
     environment:
       - DOCKER_SSL


### PR DESCRIPTION
Users currently have to customize docker-compose.yml in order to setup their deployment. However, this will usually lead to prompts to commit their dirty docker-compose.yml when updating their autolab-docker repo from upstream.

By moving these options into .env it will reduce such conflicts. However, we will still need to let users know about new config options as they are added into .env.template. 