### PR TITLE
Create docker configs on `make`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,6 @@ pipeline {
                 sh 'python3 ci_script.py -v .env'
                 sh 'docker-compose stop'
                 // configure SSL
-                sh 'make ssl'
                 sh "python3 ci_script.py -a nginx/app.conf"
                 sh 'python3 ci_script.py -s ./ssl/init-letsencrypt.sh'
                 // do not replace existing certificate

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: setup-autolab-configs setup-tango-configs
+all: setup-autolab-configs setup-tango-configs setup-docker-configs
 
 .PHONY: setup-autolab-configs
 setup-autolab-configs: 
@@ -25,6 +25,15 @@ setup-tango-configs:
 	echo "Creating default Tango/config.py"
 	cp -n ./Tango/config.template.py ./Tango/config.py
 
+.PHONY: setup-docker-configs
+setup-docker-configs:
+	echo "Creating default ssl/init-letsencrypt.sh"
+	cp -n ./ssl/init-letsencrypt.sh.template ./ssl/init-letsencrypt.sh
+	echo "Creating default nginx/app.conf"
+	cp -n ./nginx/app.conf.template ./nginx/app.conf
+	echo "Creating default nginx/no-ssl-app.conf"
+	cp -n ./nginx/no-ssl-app.conf.template ./nginx/no-ssl-app.conf
+
 .PHONY: db-migrate
 db-migrate:
 	docker exec autolab bash /home/app/webapp/docker/db_migrate.sh
@@ -44,24 +53,18 @@ set-perms:
 create-user:
 	docker exec -it autolab bash /home/app/webapp/bin/initialize_user.sh
 
-.PHONY: ssl
-ssl:
-	cp -n ./ssl/init-letsencrypt.sh.template ./ssl/init-letsencrypt.sh
-	cp -n ./nginx/app.conf.template ./nginx/app.conf
-
-.PHONY: no-ssl
-no-ssl:
-	cp -n ./nginx/no-ssl-app.conf.template ./nginx/no-ssl-app.conf
-
 
 .PHONY: clean
 clean:
+	echo "Deleting all Autolab, Tango, SSL, Nginx, Docker Compose deployment configs"
 	rm -rf ./Autolab/config/database.yml
 	rm -rf ./Autolab/config/school.yml
 	rm -rf ./Autolab/config/environments/production.rb
 	rm -rf ./Autolab/config/autogradeConfig.rb
 	rm -rf ./Tango/config.py
 	rm -rf ./ssl/init-letsencrypt.sh
+	rm -rf ./nginx/app.conf
+	rm -rf ./nginx/no-ssl-app.conf
 	rm -rf ./Autolab/log
 	rm -rf ./.env
 	# We don't remove Autolab/courses here, as it may contain important user data. Remove it yourself manually if needed.


### PR DESCRIPTION
One issue with creating SSL and Nginx configs at the end is that our CI pipeline builds and brings up the container at the start, so the missing template configs would result in Docker Compose creating a directory mapping for the files, that causes subsequent steps to fail.

Instead, we simply just always create these configs at the start, to avoid this issue