### PR TITLE
update passenger to use ruby 2.7

### DIFF
--- a/nginx/app.conf.template
+++ b/nginx/app.conf.template
@@ -23,7 +23,7 @@ server {
     passenger_enabled on;
     passenger_app_env production;
 
-    passenger_ruby /usr/bin/ruby2.6;
+    passenger_ruby /usr/bin/ruby2.7;
     passenger_user app;
 
     ssl_certificate /etc/letsencrypt/live/<REPLACE_WITH_YOUR_DOMAIN>/fullchain.pem;


### PR DESCRIPTION
Necessary with Autolab's update to Ruby 2.7.7