### PR TITLE
Update ruby version to 2.7 for passenger

### DIFF
--- a/nginx/no-ssl-app.conf.template
+++ b/nginx/no-ssl-app.conf.template
@@ -4,5 +4,5 @@ server {
   root /home/app/webapp/public;
   passenger_enabled on;
   passenger_user app;
-  passenger_ruby /usr/bin/ruby2.6;
+  passenger_ruby /usr/bin/ruby2.7;
 }


### PR DESCRIPTION
Currently, development installs using docker compose fail because the ruby version used by passenger is not updated. 