### PR TITLE
Create volume mapping for ActiveStorage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,12 +39,14 @@ services:
     # Some volume mappings may seem redundant, but we want to make it explicit
     volumes:
       - ./Autolab/db/:/home/app/webapp/db
+      - ./Autolab/attachments/:/home/app/webapp/attachments
       - ./Autolab/config/database.yml:/home/app/webapp/config/database.yml
       - ./Autolab/config/environments/production.rb:/home/app/webapp/config/environments/production.rb
       - ./Autolab/config/autogradeConfig.rb:/home/app/webapp/config/autogradeConfig.rb
       - ./Autolab/courses:/home/app/webapp/courses
       - ./Autolab/courseConfig:/home/app/webapp/courseConfig
       - ./Autolab/assessmentConfig:/home/app/webapp/assessmentConfig
+      - ./Autolab/storage/:/home/app/webapp/storage
       - ./ssl/certbot/conf:/etc/letsencrypt
       - ./ssl/certbot/www:/var/www/certbot
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,14 +38,14 @@ services:
 
     # Some volume mappings may seem redundant, but we want to make it explicit
     volumes:
-      - ./Autolab/db/:/home/app/webapp/db
+      - ./Autolab/db:/home/app/webapp/db
       - ./Autolab/config/database.yml:/home/app/webapp/config/database.yml
       - ./Autolab/config/environments/production.rb:/home/app/webapp/config/environments/production.rb
       - ./Autolab/config/autogradeConfig.rb:/home/app/webapp/config/autogradeConfig.rb
       - ./Autolab/courses:/home/app/webapp/courses
       - ./Autolab/courseConfig:/home/app/webapp/courseConfig
       - ./Autolab/assessmentConfig:/home/app/webapp/assessmentConfig
-      - ./Autolab/storage/:/home/app/webapp/storage
+      - ./Autolab/storage:/home/app/webapp/storage
       - ./ssl/certbot/conf:/etc/letsencrypt
       - ./ssl/certbot/www:/var/www/certbot
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,6 @@ services:
     # Some volume mappings may seem redundant, but we want to make it explicit
     volumes:
       - ./Autolab/db/:/home/app/webapp/db
-      - ./Autolab/attachments/:/home/app/webapp/attachments
       - ./Autolab/config/database.yml:/home/app/webapp/config/database.yml
       - ./Autolab/config/environments/production.rb:/home/app/webapp/config/environments/production.rb
       - ./Autolab/config/autogradeConfig.rb:/home/app/webapp/config/autogradeConfig.rb


### PR DESCRIPTION
Add volume mapping for `storage/`, which will be used by attachments (ActiveStorage) in the future.

Note: there is currently no mapping for `attachments/`, and adding a mapping would overwrite an existing `attachments/` directory. Since we're switching over to ActiveStorage anyway, it's better to make this non-breaking change instead.
