### PR TITLE
Increase max allowed upload size for assessments

### DIFF
--- a/nginx/app.conf.template
+++ b/nginx/app.conf.template
@@ -9,12 +9,6 @@ server {
     location / {
         return 301 https://$host$request_uri;
     }
-
-    # Set max client body size for assessments
-    # regex matches one or more alpha-numeric characters and the hyphen '-'
-    location ~* /courses/[\w|-]+/assessments/importAsmtFromTar {
-        client_max_body_size 1G;
-    }
 }
 
 server {

--- a/nginx/app.conf.template
+++ b/nginx/app.conf.template
@@ -8,7 +8,13 @@ server {
 
     location / {
         return 301 https://$host$request_uri;
-    }    
+    }
+
+    # Set max client body size for assessments
+    # regex matches one or more alpha-numeric characters and the hyphen '-'
+    location ~* /courses/[\w|-]+/assessments/importAsmtFromTar {
+        client_max_body_size 1G;
+    }
 }
 
 server {
@@ -40,5 +46,10 @@ server {
 
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
+    # Set max client body size for assessments
+    # regex matches one or more alpha-numeric characters and the hyphen '-'
+    location ~* /courses/[\w|-]+/assessments/importAsmtFromTar {
+        client_max_body_size 1G;
+    }
 }
 

--- a/nginx/no-ssl-app.conf.template
+++ b/nginx/no-ssl-app.conf.template
@@ -5,4 +5,10 @@ server {
   passenger_enabled on;
   passenger_user app;
   passenger_ruby /usr/bin/ruby2.7;
+
+  # Set max client body size for assessments
+  # regex matches one or more alpha-numeric characters and the hyphen '-'
+  location ~* /courses/[\w|-]+/assessments/importAsmtFromTar {
+    client_max_body_size 1G;
+  }
 }


### PR DESCRIPTION
This PR handles [this issue](https://github.com/autolab/Autolab/issues/1880) in the Autolab repo. I found this to be the best place to make the change.

It changes client_max_body_size to 1 Gigabyte **only** for requests going to `/courses/<course_name>/assessments/importAsmtFromTar`.

The discussed approach in the issue above would allow 1GB uploads across the website. I think the upload size for student submissions is limited on the application level, but nevertheless, it stands to reason not to allow huge uploads across the server if we can avoid that.

Notes:
- I have only tested locally without SSL. The SSL configuration is identical but let me know what is the best way to test it.
- This solves the issue for Docker Installation as far as I understand. I tried to find similar configurations for the Manual Installation but could not find any. So I assume that manual installation uses the default Rails server, and if someone wants to use a production server they will need to set it up by themselves. Let me know if my assumption is incorrect and if the configurations need to be added somewhere else too.
- Admins with existing instances need to update the conf files on their servers to get this change.