### PR TITLE
Increase max allowed upload size for autograders

### DIFF
--- a/nginx/app.conf.template
+++ b/nginx/app.conf.template
@@ -40,9 +40,13 @@ server {
 
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
-    # Set max client body size for assessments
+    # Set max client body size for assessments and autograders
     # regex matches one or more alpha-numeric characters and the hyphen '-'
     location ~* /courses/[\w|-]+/assessments/importAsmtFromTar {
+        client_max_body_size 1G;
+    }
+
+    location ~* /courses/[\w|-]+/assessments/[\w|-]+/autograder.\d+ {
         client_max_body_size 1G;
     }
 }

--- a/nginx/no-ssl-app.conf.template
+++ b/nginx/no-ssl-app.conf.template
@@ -6,9 +6,13 @@ server {
   passenger_user app;
   passenger_ruby /usr/bin/ruby2.7;
 
-  # Set max client body size for assessments
+  # Set max client body size for assessments and autograders
   # regex matches one or more alpha-numeric characters and the hyphen '-'
   location ~* /courses/[\w|-]+/assessments/importAsmtFromTar {
+    client_max_body_size 1G;
+  }
+
+  location ~* /courses/[\w|-]+/assessments/[\w|-]+/autograder.\d+ {
     client_max_body_size 1G;
   }
 }


### PR DESCRIPTION
The previous PR (#58) only handles the problem when importing an assessment from tarball. When we create an empty assessment, we are no longer able to upload a large autograder (>2M).

As discussed in autolab/Autolab#1880, this PR fixes this problem in the same manner as #58. It changes `client_max_body_size` to 1 Gigabyte for requests going to `/courses/<course_name>/assessments/<assessment_name>/autograder.<autograder_id>`. This fix works well on my local machine w/o SSL.