### PR TITLE
Increase nginx limits for handins and attachments

### DIFF
--- a/nginx/app.conf.template
+++ b/nginx/app.conf.template
@@ -40,16 +40,35 @@ server {
 
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
-    # Set max client body size for assessments and autograders
-    # regex matches one or more alpha-numeric characters and the hyphen '-'
+    # Increase max client body size for upload routes
+    # [\w|-]+ regex matches one or more alpha-numeric characters and the hyphen '-'
+
+    # Import assessment from tarball
     location ~* /courses/[\w|-]+/assessments/importAsmtFromTar {
         client_max_body_size 1G;
     }
 
+    # Autograder files (Makefile / Tar)
     location ~* /courses/[\w|-]+/assessments/[\w|-]+/autograder.\d+ {
         client_max_body_size 1G;
     }
 
+    # Course attachments
+    location ~* /courses/[\w|-]+/attachments {
+        client_max_body_size 1G;
+    }
+
+    # Assessment attachments
+    location ~* /courses/[\w|-]+/assessments/[\w|-]+/attachments {
+        client_max_body_size 1G;
+    }
+
+    # Assessment handin
+    location ~* /courses/[\w|-]+/assessments/[\w|-]+/handin {
+        client_max_body_size 1G;
+    }
+
+    # Docker image upload
     location ~* /courses/[\w|-]+/dockers/uploadDockerImage {
         client_max_body_size 10G;
     }

--- a/nginx/no-ssl-app.conf.template
+++ b/nginx/no-ssl-app.conf.template
@@ -1,22 +1,41 @@
 server {
-  listen 80;
-  server_name <REPLACE_WITH_YOUR_DOMAIN>;
-  root /home/app/webapp/public;
-  passenger_enabled on;
-  passenger_user app;
-  passenger_ruby /usr/bin/ruby2.7;
+    listen 80;
+    server_name <REPLACE_WITH_YOUR_DOMAIN>;
+    root /home/app/webapp/public;
+    passenger_enabled on;
+    passenger_user app;
+    passenger_ruby /usr/bin/ruby2.7;
 
-  # Set max client body size for assessments and autograders
-  # regex matches one or more alpha-numeric characters and the hyphen '-'
-  location ~* /courses/[\w|-]+/assessments/importAsmtFromTar {
-    client_max_body_size 1G;
-  }
+    # Increase max client body size for upload routes
+    # [\w|-]+ regex matches one or more alpha-numeric characters and the hyphen '-'
 
-  location ~* /courses/[\w|-]+/assessments/[\w|-]+/autograder.\d+ {
-    client_max_body_size 1G;
-  }
+    # Import assessment from tarball
+    location ~* /courses/[\w|-]+/assessments/importAsmtFromTar {
+        client_max_body_size 1G;
+    }
 
-  location ~* /courses/[\w|-]+/dockers/uploadDockerImage {
-    client_max_body_size 10G;
-  }
+    # Autograder files (Makefile / Tar)
+    location ~* /courses/[\w|-]+/assessments/[\w|-]+/autograder.\d+ {
+        client_max_body_size 1G;
+    }
+
+    # Course attachments
+    location ~* /courses/[\w|-]+/attachments {
+        client_max_body_size 1G;
+    }
+
+    # Assessment attachments
+    location ~* /courses/[\w|-]+/assessments/[\w|-]+/attachments {
+        client_max_body_size 1G;
+    }
+
+    # Assessment handin
+    location ~* /courses/[\w|-]+/assessments/[\w|-]+/handin {
+        client_max_body_size 1G;
+    }
+
+    # Docker image upload
+    location ~* /courses/[\w|-]+/dockers/uploadDockerImage {
+        client_max_body_size 10G;
+    }
 }


### PR DESCRIPTION
Tested by creating a 10mb file (`mkfile -n 10m handin.tgz`) and successfully
- Creating a course attachment
- Creating an assessment attachment
- Submitting to an assessment